### PR TITLE
Fix "it" snippet

### DIFF
--- a/snippets/javascript/it.snippet
+++ b/snippets/javascript/it.snippet
@@ -1,3 +1,3 @@
 it('${1:should do something}', function() {
-  ${3}
+  ${2}
 })


### PR DESCRIPTION
Hi, I started using your snippets for mocha and found that `it` doesn't work when I press `tab` second time. This change fixed the problem for me.
