### PR TITLE
Make it es6!

### DIFF
--- a/snippets/javascript/af.snippet
+++ b/snippets/javascript/af.snippet
@@ -1,3 +1,3 @@
-after(function(){
+after(() => {
   ${1}
 });

--- a/snippets/javascript/afe.snippet
+++ b/snippets/javascript/afe.snippet
@@ -1,3 +1,3 @@
-afterEach(function(){
+afterEach(() => {
   ${1}
 });

--- a/snippets/javascript/afea.snippet
+++ b/snippets/javascript/afea.snippet
@@ -1,4 +1,4 @@
-afterEach(function(${1:done}){
+afterEach((${1:done}) => {
   ${2}
   $1();
 });

--- a/snippets/javascript/bef.snippet
+++ b/snippets/javascript/bef.snippet
@@ -1,3 +1,3 @@
-before(function(){
+before(() => {
   ${1}
 });

--- a/snippets/javascript/befa.snippet
+++ b/snippets/javascript/befa.snippet
@@ -1,4 +1,4 @@
-before(function(${1:done}){
+before((${1:done}) => {
   ${2}
   $1();
 });

--- a/snippets/javascript/befe.snippet
+++ b/snippets/javascript/befe.snippet
@@ -1,3 +1,3 @@
-beforeEach(function(){
+beforeEach(() => {
   ${1}
 });

--- a/snippets/javascript/desc.snippet
+++ b/snippets/javascript/desc.snippet
@@ -1,3 +1,3 @@
-describe('${1:feature}', function(){
+describe('${1:feature}', () => {
   ${2}
 });

--- a/snippets/javascript/it.snippet
+++ b/snippets/javascript/it.snippet
@@ -1,3 +1,3 @@
-it('${1:should do something}', function(){
+it('${1:should do something}', () => {
   ${2}
 });

--- a/snippets/javascript/xit.snippet
+++ b/snippets/javascript/xit.snippet
@@ -1,3 +1,3 @@
-xit('${1:should do something}', function() {
+xit('${1:should do something}', () => {
   ${2}
 });

--- a/snippets/javascript/xita.snippet
+++ b/snippets/javascript/xita.snippet
@@ -1,4 +1,4 @@
-xit('${1:should do something}', function(${2:done}){
+xit('${1:should do something}', (${2:done}) => {
   ${3}
   $2();
 });


### PR DESCRIPTION
Hello @mmozuras!

I noticed you had this repo for mocha!

I made a PR to make it es6.

If you don't use es6 or would like these snippets to be both es5 and es6 compatible I could make this PR with a different folder that has all the prefixes with a `6` at the end or a `5` at the end if you would like the default to be es6.

Here is how it would look.

Es6 defaulted:
`it5` <= gives you es5 syntax
`it` <= gives you fat arrow syntax

Es5 defaulted:
`it` <= gives you es5 syntax
`it6` <= gives you fat arrow syntax

Or if you don't care about es5 and just want es6, merge it as is!

Completely up to you, just let me know :)
